### PR TITLE
Fix Symfony 4.0 compatibility

### DIFF
--- a/src/DependencyInjection/Compiler/BreadcrumbsProviderPass.php
+++ b/src/DependencyInjection/Compiler/BreadcrumbsProviderPass.php
@@ -101,7 +101,7 @@ final class BreadcrumbsProviderPass implements CompilerPassInterface
         $headExtras = [];
 
         $classReflection = new \ReflectionClass($class);
-        $this->container->addClassResource($classReflection);
+        $this->container->addObjectResource($class);
 
         /** @var BreadcrumbsProvider $classAnnotation */
         if ($classAnnotation = $annotationReader->getClassAnnotation($classReflection, BreadcrumbsProvider::class)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

`ContainerBuilder::addClassResource()` is deprecated.
https://github.com/symfony/symfony/pull/21419
